### PR TITLE
Fix skull counter not incrementing and add debug print for GI

### DIFF
--- a/src/box_hooks.c
+++ b/src/box_hooks.c
@@ -424,6 +424,7 @@ RECOMP_PATCH void EnBox_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList
                     gSPDisplayList((*gfx)++, &heartChestBaseDL);
                     return;
                 case GI_TRUE_SKULL_TOKEN:
+                case GI_OCEAN_SKULL_TOKEN:
                     gSPDisplayList((*gfx)++, &spiderChestBaseDL);
                     return;
                 case GI_KEY_BOSS:
@@ -460,6 +461,7 @@ RECOMP_PATCH void EnBox_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList
                     gSPDisplayList((*gfx)++, &heartChestLidDL);
                     return;
                 case GI_TRUE_SKULL_TOKEN:
+                case GI_OCEAN_SKULL_TOKEN:
                     gSPDisplayList((*gfx)++, &spiderChestLidDL);
                     return;
                 case GI_KEY_BOSS:

--- a/src/item_give.c
+++ b/src/item_give.c
@@ -1783,6 +1783,8 @@ u8 randoItemGive(u32 gi) {
     u8 item;
     u8 dungeonIndex;
     s16 old_health;
+    u32 giMasked = gi & 0xFFFFFF;
+    recomp_printf("= randoItemGive = GI: 0x%08X\n", gi);
 
     switch (gi & 0xFF0000) {
         case 0x010000:
@@ -1845,7 +1847,7 @@ u8 randoItemGive(u32 gi) {
             if (gi == 0) {
                 return ITEM_NONE;
             }
-            if (gi == GI_TRUE_SKULL_TOKEN) {
+            if (giMasked == GI_TRUE_SKULL_TOKEN || giMasked == GI_OCEAN_SKULL_TOKEN) {
                 item = ITEM_SKULL_TOKEN;
                 break;
             }
@@ -1862,7 +1864,7 @@ u8 randoItemGive(u32 gi) {
         //! @bug: Sets QUEST_QUIVER instead of QUEST_SKULL_TOKEN
         // Setting `QUEST_SKULL_TOKEN` will result in misplaced digits on the pause menu - Quest Status page.
         SET_QUEST_ITEM(item - ITEM_SKULL_TOKEN + QUEST_QUIVER);
-        Inventory_IncrementSkullTokenCount(0x27);
+        Inventory_IncrementSkullTokenCount(giMasked == GI_OCEAN_SKULL_TOKEN ? SCENE_KINDAN2 : SCENE_KINSTA1);
         return ITEM_NONE;
 
     } else if (item == ITEM_DEED_LAND) {

--- a/src/play_main_hooks.c
+++ b/src/play_main_hooks.c
@@ -344,7 +344,7 @@ void update_rando(PlayState* play) {
                 randoItemGive(GI_BOMBCHUS_20);
             }
 
-            gSaveContext.save.saveInfo.skullTokenCount &= 0xFFFF;
+            // gSaveContext.save.saveInfo.skullTokenCount &= 0xFFFF;
             gSaveContext.save.saveInfo.skullTokenCount |= rando_has_item(GI_TRUE_SKULL_TOKEN) << 0x10;
             gSaveContext.save.saveInfo.skullTokenCount |= rando_has_item(GI_OCEAN_SKULL_TOKEN);
 
@@ -367,6 +367,7 @@ void update_rando(PlayState* play) {
                         case GI_POTION_RED_BOTTLE:
                         case GI_CHATEAU_BOTTLE:
                         case GI_TRUE_SKULL_TOKEN:
+                        case GI_OCEAN_SKULL_TOKEN:
                             continue;
                     }
                     if (gi == GI_HEART_CONTAINER || gi == GI_HEART_PIECE) {


### PR DESCRIPTION
This fixes the counter, however I've encountered this bug while testing in OSH. 
![image](https://github.com/user-attachments/assets/454b249c-a9b6-45a9-a215-05c25ea5c826)
The text box says 1st, but the counter clearly says 2, and I had indeed collected 2. 

Hypothesis: the save init probably sets it to -1 instead of 0?

Leaving it as a draft for now