### PR TITLE
add goron checks

### DIFF
--- a/src/goron_child_hooks.c
+++ b/src/goron_child_hooks.c
@@ -1,0 +1,146 @@
+#include "modding.h"
+#include "global.h"
+
+#include "apcommon.h"
+
+#define LOCATION_LULLABY GI_AD
+
+struct EnGk;
+
+typedef void (*EnGkActionFunc)(struct EnGk*, PlayState*);
+
+#define ENGK_GET_F(thisx) ((thisx)->params & 0xF)
+#define ENGK_GET_PATH_INDEX(thisx) (((thisx)->params & 0xF0) >> 4)
+#define ENGK_GET_SWITCH_FLAG(thisx) (((thisx)->params & 0x3F00) >> 8)
+
+#define ENGK_PATH_INDEX_NONE 0xF
+
+#define OBJECT_GK_LIMB_MAX 0x14
+#define ENGK_ANIM_3 0x3
+
+typedef enum {
+    /* 0 */ ENGK_F_0,
+    /* 1 */ ENGK_F_1,
+    /* 2 */ ENGK_F_2,
+    /* 3 */ ENGK_F_3,
+    /* 4 */ ENGK_F_4,
+    /* 5 */ ENGK_F_5
+} EnGkParam;
+
+typedef struct EnGk {
+    /* 0x000 */ Actor actor;
+    /* 0x144 */ ColliderCylinder collider;
+    /* 0x190 */ SkelAnime skelAnime;
+    /* 0x1D4 */ EnGkActionFunc actionFunc;
+    /* 0x1D8 */ Vec3s unk_1D8;
+    /* 0x1DE */ Vec3s unk_1DE;
+    /* 0x1E4 */ u16 unk_1E4;
+    /* 0x1E8 */ Path* path;
+    /* 0x1EC */ s32 unk_1EC;
+    /* 0x1F0 */ Vec3s jointTable[OBJECT_GK_LIMB_MAX];
+    /* 0x1F0 */ Vec3s morphTable[OBJECT_GK_LIMB_MAX];
+    /* 0x2E0 */ s16 unk_2E0;
+    /* 0x2E2 */ s16 unk_2E2;
+    /* 0x2E4 */ s16 animIndex;
+    /* 0x2E8 */ Vec3f unk_2E8;
+    /* 0x2F4 */ Vec3f unk_2F4;
+    /* 0x300 */ Vec3f unk_300;
+    /* 0x30C */ Vec3f unk_30C;
+    /* 0x318 */ s16 csId;
+    /* 0x31A */ u8 csAnimIndex;
+    /* 0x31B */ u8 cueId;
+    /* 0x31C */ u16 unk_31C;
+    /* 0x31E */ s16 unk_31E;
+    /* 0x320 */ s16 unk_320;
+    /* 0x322 */ s16 unk_322;
+    /* 0x324 */ s16 unk_324;
+    /* 0x328 */ Vec3f unk_328;
+    /* 0x334 */ Vec3s unk_334;
+    /* 0x33C */ Vec3f unk_33C;
+    /* 0x348 */ Vec3s unk_348;
+    /* 0x34E */ s16 unk_34E;
+    /* 0x350 */ s16 unk_350;
+    /* 0x354 */ f32 unk_354;
+} EnGk; // size = 0x358
+
+#define ENGK_ANIM_MAX 0xD
+
+extern AnimationHeader object_gk_Anim_00787C;
+extern AnimationHeader object_gk_Anim_007DC4;
+extern AnimationHeader object_gk_Anim_0092C0;
+extern AnimationHeader object_gk_Anim_005EDC;
+extern AnimationHeader object_gk_Anim_009638;
+extern AnimationHeader object_gk_Anim_008774;
+extern AnimationHeader object_gk_Anim_00AE34;
+extern AnimationHeader object_gk_Anim_00BD90;
+extern AnimationHeader object_gk_Anim_00C308;
+extern AnimationHeader object_gk_Anim_009858;
+extern AnimationHeader object_gk_Anim_009D88;
+extern AnimationHeader object_gk_Anim_00A21C;
+extern AnimationHeader object_gk_Anim_00AAEC;
+
+static AnimationInfo sAnimationInfo[ENGK_ANIM_MAX] = {
+    { &object_gk_Anim_00787C, 1.0f, 0.0f, 0.0f, ANIMMODE_LOOP, 0.0f }, // ENGK_ANIM_0
+    { &object_gk_Anim_007DC4, 1.0f, 0.0f, 0.0f, ANIMMODE_ONCE, 0.0f }, // ENGK_ANIM_1
+    { &object_gk_Anim_0092C0, 1.0f, 0.0f, 0.0f, ANIMMODE_LOOP, 0.0f }, // ENGK_ANIM_2
+    { &object_gk_Anim_005EDC, 1.0f, 0.0f, 0.0f, ANIMMODE_LOOP, 0.0f }, // ENGK_ANIM_3
+    { &object_gk_Anim_009638, 1.0f, 0.0f, 0.0f, ANIMMODE_LOOP, 0.0f }, // ENGK_ANIM_4
+    { &object_gk_Anim_008774, 1.0f, 0.0f, 0.0f, ANIMMODE_LOOP, 0.0f }, // ENGK_ANIM_5
+    { &object_gk_Anim_00AE34, 1.0f, 0.0f, 0.0f, ANIMMODE_LOOP, 0.0f }, // ENGK_ANIM_6
+    { &object_gk_Anim_00BD90, 1.0f, 0.0f, 0.0f, ANIMMODE_ONCE, 0.0f }, // ENGK_ANIM_7
+    { &object_gk_Anim_00C308, 1.0f, 0.0f, 0.0f, ANIMMODE_LOOP, 0.0f }, // ENGK_ANIM_8
+    { &object_gk_Anim_009858, 1.0f, 0.0f, 0.0f, ANIMMODE_ONCE, 0.0f }, // ENGK_ANIM_9
+    { &object_gk_Anim_009D88, 1.0f, 0.0f, 0.0f, ANIMMODE_LOOP, 0.0f }, // ENGK_ANIM_10
+    { &object_gk_Anim_00A21C, 1.0f, 0.0f, 0.0f, ANIMMODE_ONCE, 0.0f }, // ENGK_ANIM_11
+    { &object_gk_Anim_00AAEC, 1.0f, 0.0f, 0.0f, ANIMMODE_LOOP, 0.0f }, // ENGK_ANIM_12
+};
+
+void func_80B521E8(EnGk* this, PlayState* play);
+
+void EnGk_AfterLullaby(EnGk* this, PlayState* play) {
+    Flags_SetSwitch(play, ENGK_GET_SWITCH_FLAG(&this->actor));
+    this->animIndex = ENGK_ANIM_3;
+    Actor_ChangeAnimationByInfo(&this->skelAnime, sAnimationInfo, ENGK_ANIM_3);
+    // @ap set goron child to be talked to after playing lullaby just in case it isn't done earlier
+    SET_WEEKEVENTREG(WEEKEVENTREG_24_80);
+    this->actionFunc = func_80B521E8;
+}
+
+void EnGk_OfferFullLullaby(EnGk* this, PlayState* play) {
+    if (Actor_HasParent(&this->actor, play)) {
+        this->actor.parent = NULL;
+        this->actionFunc = EnGk_AfterLullaby;
+    } else {
+        Actor_OfferGetItemHook(&this->actor, play, rando_get_item_id(LOCATION_LULLABY), LOCATION_LULLABY, 300.0f, 300.0f, true, true);
+    }
+}
+
+RECOMP_PATCH s32 func_80B50854(EnGk* this, PlayState* play) {
+    Player* player = GET_PLAYER(play);
+
+    if (!(this->unk_1E4 & 0x40)) {
+        if (player->stateFlags2 & PLAYER_STATE2_8000000) {
+            this->unk_1E4 |= 0x40;
+            Audio_PlaySfx(NA_SE_SY_TRE_BOX_APPEAR);
+        }
+    } else if (!(player->stateFlags2 & PLAYER_STATE2_8000000)) {
+        this->unk_1E4 &= ~0x40;
+    }
+
+    // TODO: have this activate with lullaby intro as well (disable lullaby intro check?)
+    if ((player->transformation == PLAYER_FORM_GORON) && (play->msgCtx.ocarinaMode == OCARINA_MODE_EVENT) &&
+        (play->msgCtx.lastPlayedSong == OCARINA_SONG_GORON_LULLABY)) {
+        
+        if (!rando_location_is_checked(LOCATION_LULLABY)) {
+            this->actionFunc = EnGk_OfferFullLullaby;
+            return true;
+        }
+
+        Flags_SetSwitch(play, ENGK_GET_SWITCH_FLAG(&this->actor));
+        this->animIndex = ENGK_ANIM_3;
+        Actor_ChangeAnimationByInfo(&this->skelAnime, sAnimationInfo, ENGK_ANIM_3);
+        this->actionFunc = func_80B521E8;
+        return true;
+    }
+    return false;
+}

--- a/src/goron_elder_hooks.c
+++ b/src/goron_elder_hooks.c
@@ -1,0 +1,196 @@
+#include "modding.h"
+#include "global.h"
+
+#include "apcommon.h"
+
+// TODO: change location to lullaby intro GI / other solution
+#define LOCATION_LULLABY_INTRO (0x000100 | GI_AD)
+
+#define EN_JG_IS_IN_GORON_SHRINE(thisx) ((thisx)->params & 0x1)
+#define EN_JG_GET_PATH_INDEX(thisx) (((thisx)->params & 0xFC00) >> 10)
+
+#define EN_JG_PATH_INDEX_NONE 0x3F
+
+#define FLAG_SHRINE_GORON_ARMS_RAISED (1 << 0)
+#define FLAG_LOOKING_AT_PLAYER (1 << 2)
+#define FLAG_DRUM_SPAWNED (1 << 3)
+
+#define THIS ((EnJg*)thisx)
+
+#define EN_JG_ACTION_FIRST_THAW 0x0
+#define GORON_ELDER_LIMB_MAX 0x23
+
+struct EnJg;
+
+typedef void (*EnJgActionFunc)(struct EnJg*, PlayState*);
+
+typedef struct EnJg {
+    /* 0x000 */ Actor actor;
+    /* 0x144 */ Actor* shrineGoron;
+    /* 0x148 */ Actor* icePoly;
+    /* 0x14C */ ColliderCylinder collider;
+    /* 0x198 */ SkelAnime skelAnime;
+    /* 0x1DC */ EnJgActionFunc actionFunc;
+    /* 0x1E0 */ Path* path;
+    /* 0x1E4 */ s32 currentPoint;
+    /* 0x1E8 */ Actor* drum;
+    /* 0x1EC */ Vec3s unusedRotation1; // probably meant to be a head rotation to look at the player
+    /* 0x1F2 */ Vec3s unusedRotation2; // probably meant to be a body rotation to look at the player
+    /* 0x1F8 */ Vec3s jointTable[GORON_ELDER_LIMB_MAX];
+    /* 0x2CA */ Vec3s morphTable[GORON_ELDER_LIMB_MAX];
+    /* 0x39C */ s16 rootRotationWhenTalking;
+    /* 0x39E */ s16 animIndex;
+    /* 0x3A0 */ s16 action;
+    /* 0x3A2 */ s16 freezeTimer;
+    /* 0x3A4 */ Vec3f breathPos;
+    /* 0x3B0 */ Vec3f breathVelocity;
+    /* 0x3BC */ Vec3f breathAccel;
+    /* 0x3C8 */ s16 csId;
+    /* 0x3CA */ u8 csAnimIndex;
+    /* 0x3CB */ u8 cueId;
+    /* 0x3CC */ u16 flags;
+    /* 0x3CE */ u16 textId;
+    /* 0x3D0 */ u8 focusedShrineGoronParam;
+} EnJg; // size = 0x3D4
+
+typedef enum EnJgAnimation {
+    /*  0 */ EN_JG_ANIM_IDLE,
+    /*  1 */ EN_JG_ANIM_WALK,
+    /*  2 */ EN_JG_ANIM_WAVING,
+    /*  3 */ EN_JG_ANIM_SHAKING_HEAD,
+    /*  4 */ EN_JG_ANIM_SURPRISE_START,
+    /*  5 */ EN_JG_ANIM_SURPRISE_LOOP,
+    /*  6 */ EN_JG_ANIM_ANGRY,
+    /*  7 */ EN_JG_ANIM_FROZEN_START,
+    /*  8 */ EN_JG_ANIM_FROZEN_LOOP,
+    /*  9 */ EN_JG_ANIM_WALK_2,
+    /* 10 */ EN_JG_ANIM_TAKING_OUT_DRUM,
+    /* 11 */ EN_JG_ANIM_DRUM_IDLE,
+    /* 12 */ EN_JG_ANIM_PLAYING_DRUM,
+    /* 13 */ EN_JG_ANIM_THINKING,
+    /* 14 */ EN_JG_ANIM_REMEMBERING,
+    /* 15 */ EN_JG_ANIM_STRONG_REMEMBERING,
+    /* 16 */ EN_JG_ANIM_DEPRESSED,
+    /* 17 */ EN_JG_ANIM_CUTSCENE_IDLE,
+    /* 18 */ EN_JG_ANIM_CRADLE,
+    /* 19 */ EN_JG_ANIM_MAX
+} EnJgAnimation;
+
+extern AnimationHeader gGoronElderIdleAnim;
+extern AnimationHeader gGoronElderWalkAnim;
+extern AnimationHeader gGoronElderWavingAnim;
+extern AnimationHeader gGoronElderHeadShakeAnim;
+extern AnimationHeader gGoronElderSurpriseStartAnim;
+extern AnimationHeader gGoronElderSurpriseLoopAnim;
+extern AnimationHeader gGoronElderAngryAnim;
+extern AnimationHeader gGoronElderTakeOutDrumAnim;
+extern AnimationHeader gGoronElderDrumIdleAnim;
+extern AnimationHeader gGoronElderPlayingDrumAnim;
+extern AnimationHeader gGoronElderThinkingAnim;
+extern AnimationHeader gGoronElderRememberingAnim;
+extern AnimationHeader gGoronElderStrongRememberingAnim;
+extern AnimationHeader gGoronElderDepressedAnim;
+extern AnimationHeader gGoronElderCradleAnim;
+
+static AnimationInfoS sAnimationInfo[EN_JG_ANIM_MAX] = {
+    { &gGoronElderIdleAnim, 1.0f, 0, -1, ANIMMODE_LOOP, -10 },            // EN_JG_ANIM_IDLE
+    { &gGoronElderWalkAnim, 1.0f, 0, -1, ANIMMODE_LOOP, -10 },            // EN_JG_ANIM_WALK
+    { &gGoronElderWavingAnim, 1.0f, 0, -1, ANIMMODE_LOOP, -10 },          // EN_JG_ANIM_WAVING
+    { &gGoronElderHeadShakeAnim, 1.0f, 0, -1, ANIMMODE_LOOP, -10 },       // EN_JG_ANIM_SHAKING_HEAD
+    { &gGoronElderSurpriseStartAnim, 1.0f, 0, -1, ANIMMODE_ONCE, -10 },   // EN_JG_ANIM_SURPRISE_START
+    { &gGoronElderSurpriseLoopAnim, 1.0f, 0, -1, ANIMMODE_LOOP, -10 },    // EN_JG_ANIM_SURPRISE_LOOP
+    { &gGoronElderAngryAnim, 1.0f, 0, -1, ANIMMODE_LOOP, -10 },           // EN_JG_ANIM_ANGRY
+    { &gGoronElderSurpriseStartAnim, 2.0f, 0, -1, ANIMMODE_ONCE, 0 },     // EN_JG_ANIM_FROZEN_START
+    { &gGoronElderSurpriseStartAnim, -2.0f, 0, -1, ANIMMODE_ONCE, 0 },    // EN_JG_ANIM_FROZEN_LOOP
+    { &gGoronElderWalkAnim, -1.0f, 0, -1, ANIMMODE_LOOP, -10 },           // EN_JG_ANIM_WALK_2
+    { &gGoronElderTakeOutDrumAnim, 1.0f, 0, -1, ANIMMODE_ONCE, 0 },       // EN_JG_ANIM_TAKING_OUT_DRUM
+    { &gGoronElderDrumIdleAnim, 1.0f, 0, -1, ANIMMODE_LOOP, 0 },          // EN_JG_ANIM_DRUM_IDLE
+    { &gGoronElderPlayingDrumAnim, 1.0f, 1, 44, ANIMMODE_ONCE, 0 },       // EN_JG_ANIM_PLAYING_DRUM
+    { &gGoronElderThinkingAnim, 1.0f, 0, -1, ANIMMODE_LOOP, 0 },          // EN_JG_ANIM_THINKING
+    { &gGoronElderRememberingAnim, 1.0f, 0, -1, ANIMMODE_ONCE, 0 },       // EN_JG_ANIM_REMEMBERING
+    { &gGoronElderStrongRememberingAnim, 1.0f, 0, -1, ANIMMODE_ONCE, 0 }, // EN_JG_ANIM_STRONG_REMEMBERING
+    { &gGoronElderDepressedAnim, 1.0f, 0, -1, ANIMMODE_LOOP, 0 },         // EN_JG_ANIM_DEPRESSED
+    { &gGoronElderIdleAnim, 1.0f, 0, -1, ANIMMODE_LOOP, 0 },              // EN_JG_ANIM_CUTSCENE_IDLE
+    { &gGoronElderCradleAnim, 1.0f, 0, -1, ANIMMODE_LOOP, 0 },            // EN_JG_ANIM_CRADLE
+};
+
+static Vec3f sSfxPos = { 0.0f, 0.0f, 0.0f };
+
+void EnJg_SetupWalk(EnJg* this, PlayState* play);
+void EnJg_Talk(EnJg* this, PlayState* play);
+void EnJg_AlternateTalkOrWalkInPlace(EnJg* this, PlayState* play);
+
+void EnJg_FinishOffer(EnJg* this, PlayState* play) {
+    play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
+    play->msgCtx.stateTimer = 4;
+    this->flags &= ~FLAG_LOOKING_AT_PLAYER;
+    this->actionFunc = EnJg_SetupWalk;
+}
+
+void EnJg_OfferLullabyIntro(EnJg* this, PlayState* play) {
+    if (Actor_HasParent(&this->actor, play)) {
+        this->actor.parent = NULL;
+        this->actionFunc = EnJg_FinishOffer;
+    } else {
+        Actor_OfferGetItemHook(&this->actor, play, rando_get_item_id(LOCATION_LULLABY_INTRO), LOCATION_LULLABY_INTRO, 300.0f, 300.0f, true, true);
+    }
+}
+
+RECOMP_PATCH void EnJg_SetupTalk(EnJg* this, PlayState* play) {
+    switch (this->textId) {
+        case 0xDAC: // What was I doing?
+            Player* player = GET_PLAYER(play);
+            if (!rando_location_is_checked(GI_AD) && player->transformation == PLAYER_FORM_GORON && CHECK_WEEKEVENTREG(WEEKEVENTREG_24_80)) {
+                Message_CloseTextbox(play);
+                this->actionFunc = EnJg_OfferLullabyIntro;
+                break;
+            }
+
+            this->animIndex = EN_JG_ANIM_SHAKING_HEAD;
+            SubS_ChangeAnimationByInfoS(&this->skelAnime, sAnimationInfo, this->animIndex);
+            this->actionFunc = EnJg_Talk;
+            break;
+
+        case 0xDAD: // I must hurry!
+            this->animIndex = EN_JG_ANIM_SURPRISE_START;
+            SubS_ChangeAnimationByInfoS(&this->skelAnime, sAnimationInfo, this->animIndex);
+            this->actionFunc = EnJg_AlternateTalkOrWalkInPlace;
+            break;
+
+        case 0xDB7: // You're Darmani!
+            this->animIndex = EN_JG_ANIM_SURPRISE_START;
+            SubS_ChangeAnimationByInfoS(&this->skelAnime, sAnimationInfo, this->animIndex);
+            this->actionFunc = EnJg_Talk;
+            break;
+
+        case 0xDAE: // Do you have business with the Elder?
+        case 0xDB3: // As Elder, I must do something
+        case 0xDB6: // "Hunh???"
+        case 0xDBA: // I've been made a fool of!
+        case 0xDBD: // "...What?"
+        case 0xDC4: // It's so cold I can't play
+            this->animIndex = EN_JG_ANIM_IDLE;
+            SubS_ChangeAnimationByInfoS(&this->skelAnime, sAnimationInfo, this->animIndex);
+            this->actionFunc = EnJg_Talk;
+            break;
+
+        case 0xDB0: // It's this cold snap
+        case 0xDBB: // If I can see past the illusion, you'll vanish
+        case 0xDBC: // Following me won't do you any good
+        case 0xDC6: // I am counting on you
+            this->animIndex = EN_JG_ANIM_ANGRY;
+            SubS_ChangeAnimationByInfoS(&this->skelAnime, sAnimationInfo, this->animIndex);
+            this->actionFunc = EnJg_Talk;
+            break;
+
+        case 0xDB4: // This is our problem (first)
+        case 0xDB5: // This is our problem (repeat)
+            this->animIndex = EN_JG_ANIM_WAVING;
+            SubS_ChangeAnimationByInfoS(&this->skelAnime, sAnimationInfo, this->animIndex);
+            this->actionFunc = EnJg_Talk;
+            break;
+
+        default:
+            break;
+    }
+}

--- a/src/snowball_hooks.c
+++ b/src/snowball_hooks.c
@@ -1,0 +1,55 @@
+#include "modding.h"
+#include "global.h"
+
+struct ObjSnowball;
+
+typedef void (*ObjSnowballActionFunc)(struct ObjSnowball*, PlayState*);
+
+typedef struct {
+    /* 0x00 */ Vec3f unk_00;
+    /* 0x0C */ f32 unk_0C;
+    /* 0x10 */ f32 unk_10;
+    /* 0x14 */ f32 unk_14;
+    /* 0x18 */ f32 unk_18;
+    /* 0x1C */ Vec3s unk_1C;
+    /* 0x22 */ s16 unk_22;
+    /* 0x24 */ s16 unk_24;
+    /* 0x26 */ s16 unk_26;
+    /* 0x28 */ CollisionPoly* unk_28;
+    /* 0x2C */ u8 unk_2C;
+    /* 0x2D */ u8 unk_2D;
+} ObjSnowballStruct; // size = 0x30
+
+typedef struct ObjSnowball {
+    /* 0x000 */ Actor actor;
+    /* 0x144 */ ColliderJntSph collider;
+    /* 0x164 */ ColliderJntSphElement colliderElements[1];
+    /* 0x1A4 */ ObjSnowballActionFunc actionFunc;
+    /* 0x1A8 */ ObjSnowballStruct unk_1A8[2];
+    /* 0x208 */ s8 unk_208;
+    /* 0x209 */ s8 unk_209;
+    /* 0x20A */ s8 unk_20A;
+    /* 0x20B */ s8 unk_20B;
+    /* 0x20C */ f32 unk_20C;
+    /* 0x210 */ s8 unk_210;
+    /* 0x211 */ s8 unk_211;
+} ObjSnowball; // size = 0x214
+
+void func_80B03FF8(ObjSnowball* this, PlayState* play);
+void func_80B04608(ObjSnowball* this, PlayState* play);
+void func_80B046E4(ObjSnowball* this, PlayState* play);
+
+RECOMP_PATCH void func_80B0457C(ObjSnowball* this, PlayState* play) {
+    if (CutsceneManager_IsNext(this->actor.csId)) {
+        // CutsceneManager_StartWithPlayerCs(this->actor.csId, &this->actor);
+        func_80B03FF8(this, play);
+        this->unk_20B = 1;
+        if (this->unk_20A == 0) {
+            func_80B04608(this, play);
+        } else {
+            func_80B046E4(this, play);
+        }
+    } else {
+        CutsceneManager_Queue(this->actor.csId);
+    }
+}


### PR DESCRIPTION
Adds ~~big ol' Goron cheeks~~ both Goron Lullaby locations as checks and skips their cutscenes. Also skips the snowballs being destroyed cutscene because it got annoying in testing this.

Few notes regarding this:
- The location for the Goron Elder teaching Lullaby Intro should be changed
  - This could either be a Lullaby Intro GI or something else
- To get the Goron Elder check, you need to talk to the child first and be a Goron
  - Playing Lullaby to get the child's check will also count as talking to the child
- Goron Child does not account for when Lullaby Intro is played