### PR TITLE
fix(macos): allow overriding on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ LIB_DIRS := lib
 OUTPUT_NAME := mm_recomp_rando
 MOD_TOML := mod.toml
 
+# Allow the user to specify the compiler and linker on macOS
+# as Apple Clang does not support MIPS architecture
 ifeq ($(shell uname),Darwin)
     CC      ?= clang
     LD      ?= ld.lld


### PR DESCRIPTION
Re-enables overriding compiler and linker but one for macOS as it previously broke it for others here: #78