### PR TITLE
Add Modern Controller Overhaul compatibility, doesn't break anything without it installed.

### DIFF
--- a/rando_syms.toml
+++ b/rando_syms.toml
@@ -38,3 +38,14 @@ size = 0x194A0
 symbols = [
     { name = "sReactionTextIds", vram = 0x801BC420}
 ]
+
+[[section]]
+name = "..code"
+rom = 0x00B3C000
+vram = 0x800A5AC0
+size = 0x13E4E0
+
+symbols = [
+    { name = "sAmmoDigitsXPositions", vram = 0x801BFB04 },
+    { name = "sAmmoDigitsYPositions", vram = 0x801BFB0C }
+]

--- a/src/ui_hooks.c
+++ b/src/ui_hooks.c
@@ -689,10 +689,11 @@ RECOMP_PATCH void KaleidoScope_DrawAmmoCount(PauseContext* pauseCtx, GraphicsCon
 #define AMMO_DIGIT_TEX_HEIGHT  8
 #define AMMO_DIGIT_TEX_SIZE  (AMMO_DIGIT_TEX_WIDTH * AMMO_DIGIT_TEX_HEIGHT)
 
+extern s16 D_801BFB04[4];
+extern s16 D_801BFB0C[4];
+
 // @ap Draw green 10 Bombchu ammo count if no bomb bag.
 RECOMP_PATCH void Interface_DrawAmmoCount(PlayState* play, s16 button, s16 alpha) {
-    static s16 sAmmoDigitsXPositions[] = { 162, 228, 250, 272 };
-    static s16 sAmmoDigitsYPositions[] = { 35, 35, 51, 35 };
     u8 i;
     u16 ammo;
 
@@ -754,14 +755,14 @@ RECOMP_PATCH void Interface_DrawAmmoCount(PlayState* play, s16 button, s16 alpha
         if ((u32)i != 0) {
             OVERLAY_DISP =
                 Gfx_DrawTexRectIA8(OVERLAY_DISP, (u8*)gAmmoDigit0Tex + i * AMMO_DIGIT_TEX_SIZE, AMMO_DIGIT_TEX_WIDTH,
-                                   AMMO_DIGIT_TEX_HEIGHT, sAmmoDigitsXPositions[button], sAmmoDigitsYPositions[button],
+                                   AMMO_DIGIT_TEX_HEIGHT, D_801BFB04[button], D_801BFB0C[button],
                                    AMMO_DIGIT_TEX_WIDTH, AMMO_DIGIT_TEX_HEIGHT, 1 << 10, 1 << 10);
         }
 
         // Draw lower digit (ones)
         OVERLAY_DISP =
             Gfx_DrawTexRectIA8(OVERLAY_DISP, (u8*)gAmmoDigit0Tex + ammo * AMMO_DIGIT_TEX_SIZE, AMMO_DIGIT_TEX_WIDTH,
-                               AMMO_DIGIT_TEX_HEIGHT, sAmmoDigitsXPositions[button] + 6, sAmmoDigitsYPositions[button],
+                               AMMO_DIGIT_TEX_HEIGHT, D_801BFB04[button] + 6, D_801BFB0C[button],
                                AMMO_DIGIT_TEX_WIDTH, AMMO_DIGIT_TEX_HEIGHT, 1 << 10, 1 << 10);
     }
 

--- a/src/ui_hooks.c
+++ b/src/ui_hooks.c
@@ -689,8 +689,8 @@ RECOMP_PATCH void KaleidoScope_DrawAmmoCount(PauseContext* pauseCtx, GraphicsCon
 #define AMMO_DIGIT_TEX_HEIGHT  8
 #define AMMO_DIGIT_TEX_SIZE  (AMMO_DIGIT_TEX_WIDTH * AMMO_DIGIT_TEX_HEIGHT)
 
-extern s16 D_801BFB04[4];
-extern s16 D_801BFB0C[4];
+extern s16 sAmmoDigitsXPositions[4];
+extern s16 sAmmoDigitsYPositions[4];
 
 // @ap Draw green 10 Bombchu ammo count if no bomb bag.
 RECOMP_PATCH void Interface_DrawAmmoCount(PlayState* play, s16 button, s16 alpha) {
@@ -755,14 +755,14 @@ RECOMP_PATCH void Interface_DrawAmmoCount(PlayState* play, s16 button, s16 alpha
         if ((u32)i != 0) {
             OVERLAY_DISP =
                 Gfx_DrawTexRectIA8(OVERLAY_DISP, (u8*)gAmmoDigit0Tex + i * AMMO_DIGIT_TEX_SIZE, AMMO_DIGIT_TEX_WIDTH,
-                                   AMMO_DIGIT_TEX_HEIGHT, D_801BFB04[button], D_801BFB0C[button],
+                                   AMMO_DIGIT_TEX_HEIGHT, sAmmoDigitsXPositions[button], sAmmoDigitsYPositions[button],
                                    AMMO_DIGIT_TEX_WIDTH, AMMO_DIGIT_TEX_HEIGHT, 1 << 10, 1 << 10);
         }
 
         // Draw lower digit (ones)
         OVERLAY_DISP =
             Gfx_DrawTexRectIA8(OVERLAY_DISP, (u8*)gAmmoDigit0Tex + ammo * AMMO_DIGIT_TEX_SIZE, AMMO_DIGIT_TEX_WIDTH,
-                               AMMO_DIGIT_TEX_HEIGHT, D_801BFB04[button] + 6, D_801BFB0C[button],
+                               AMMO_DIGIT_TEX_HEIGHT, sAmmoDigitsXPositions[button] + 6, sAmmoDigitsYPositions[button],
                                AMMO_DIGIT_TEX_WIDTH, AMMO_DIGIT_TEX_HEIGHT, 1 << 10, 1 << 10);
     }
 


### PR DESCRIPTION
Fixes the misaligned ammo placement issue with MCO by making Interface_DrawAmmoCount use an extern for its X and Y positions instead of a static.

I've tested with:

- just rando (and dependencies) enabled.
- just rando and MCO.
- rando, MCO, and the rest of my modlist.

And it looks to be good in all of them.